### PR TITLE
Optional Prometheus exporter for mongodb-replicaset

### DIFF
--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 2.1.4
+version: 2.2.0
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.
 icon: https://webassets.mongodb.com/_com_assets/cms/mongodb-logo-rgb-j6w271g1xn.jpg

--- a/stable/mongodb-replicaset/Chart.yaml
+++ b/stable/mongodb-replicaset/Chart.yaml
@@ -1,6 +1,6 @@
 name: mongodb-replicaset
 home: https://github.com/mongodb/mongo
-version: 2.2.0
+version: 2.2.0-0.0.1
 description: NoSQL document-oriented database that stores JSON-like documents with
   dynamic schemas, simplifying the integration of data in content-driven applications.
 icon: https://webassets.mongodb.com/_com_assets/cms/mongodb-logo-rgb-j6w271g1xn.jpg

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -295,3 +295,11 @@ connecting to: mongodb://127.0.0.1:27017
 ### Scaling
 
 Scaling should be managed by `helm upgrade`, which is the recommended way.
+
+## Metrics
+The chart optionally can start a metrics exporter for [prometheus](https://prometheus.io).
+The metrics endpoint (port 9001) is exposed in the service. Metrics can be
+scraped from within the cluster using something similar as the described in the
+[example Prometheus scrape configuration](https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus-kubernetes.yml).
+Custom labels may be applied using the `metrics.serviceLabels` value for monitoring
+with [Prometheus-Operator](https://github.com/coreos/prometheus-operator).

--- a/stable/mongodb-replicaset/README.md
+++ b/stable/mongodb-replicaset/README.md
@@ -39,6 +39,13 @@ The following tables lists the configurable parameters of the mongodb chart and 
 | `image.name`                    | MongoDB image name                                                        | mongo                                               |
 | `image.tag`                     | MongoDB image tag                                                         | 3.4                                                 |
 | `image.pullPolicy`              | MongoDB image pull policy                                                 | IfNotPresent                                        |
+| `metrics.enabled`               | If `true`, Prometheus metrics exporter is enabled                         | `false`                                             |
+| `metrics.image`                 | Image name for the metrics exporter container                             | reactioncommerce/mongdb_exporter                    |
+| `metrics.imageTag`              | Image tag for the metrics exporter container                              | v1.1.0                                              |
+| `metrics.imagePullPolicy`       | Image pull policy for the metrics exporter container                      | IfNotPresent                                        |
+| `metrics.port`                  | Metrics port                                                              | 9001                                                |
+| `metrics.serviceLabels`         | Additional labels applied if metrics enabled is `true`                    | {}                                                  |
+| `metrics.env.MONGODB_URL`       | Custom metrics MongoDB URL, provided to customize connection params       | mongodb://127.0.0.1:27017                           |
 | `podAnnotations`                | Annotations to be added to MongoDB pods                                   | {}                                                  |
 | `resources`                     | Pod resource requests and limits                                          | {}                                                  |
 | `persistentVolume.enabled`      | If `true`, persistent volume claims are created                           | `true`                                              |

--- a/stable/mongodb-replicaset/templates/mongodb-service.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-service.yaml
@@ -4,19 +4,26 @@ kind: Service
 metadata:
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
-  {{- if .Values.serviceAnnotations }}
+{{- if .Values.serviceAnnotations }}
 {{ toYaml .Values.serviceAnnotations | indent 4 }}
-  {{- end }}
+{{- end }}
   labels:
     app: {{ template "mongodb-replicaset.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+{{- if .Values.metrics.enabled }}
+{{ toYaml .Values.metrics.serviceLabels | indent 4 }}
+{{- end }}
   name: {{ template "mongodb-replicaset.fullname" . }}
 spec:
   type: ClusterIP
   clusterIP: None
   ports:
+{{- if .Values.metrics.enabled }}
+    - name: metrics
+      port: {{ .Values.metrics.port }}
+{{- end }}
     - name: peer
       port: {{ .Values.port }}
   selector:

--- a/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
+++ b/stable/mongodb-replicaset/templates/mongodb-statefulset.yaml
@@ -82,6 +82,17 @@ spec:
               readOnly: true
           {{- end }}
       containers:
+{{- if .Values.metrics.enabled }}
+        - name: metrics
+          image: "{{ .Values.metrics.image }}:{{ .Values.metrics.imageTag }}"
+          imagePullPolicy: "{{ .Values.metrics.imagePullPolicy }}"
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.metrics.port }}
+          env:
+            - name: MONGODB_URL
+              value: {{ .Values.metrics.env.MONGODB_URL }}
+{{- end }}
         - name: {{ template "mongodb-replicaset.name" . }}
           image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -16,7 +16,6 @@ metrics:
   imagePullPolicy: IfNotPresent
   imageTag: latest
   port: 9001
-  resources: {}
   serviceLabels: {}
   env:
     MONGODB_URL: mongodb://127.0.0.1:27017

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -10,6 +10,17 @@ auth:
   # existingKeySecret:
   # existingAdminSecret:
 
+metrics:
+  enabled: false
+  image: reactioncommerce/mongodb_exporter
+  imagePullPolicy: IfNotPresent
+  imageTag: latest
+  port: 9001
+  resources: {}
+  serviceLabels: {}
+  env:
+    MONGODB_URL: mongodb://127.0.0.1:27017
+
 # Specs for the Docker image for the init container that establishes the replica set
 installImage:
   name: gcr.io/google_containers/mongodb-install

--- a/stable/mongodb-replicaset/values.yaml
+++ b/stable/mongodb-replicaset/values.yaml
@@ -14,7 +14,7 @@ metrics:
   enabled: false
   image: reactioncommerce/mongodb_exporter
   imagePullPolicy: IfNotPresent
-  imageTag: latest
+  imageTag: v1.1.0
   port: 9001
   serviceLabels: {}
   env:


### PR DESCRIPTION
Adds a sidecar that provides Prometheus metrics for the mongodb-replicaset chart. Disabled by default.

Compatible with both Prometheus and Prometheus Operator. In the case of Prometheus Operator you may include custom labels in the `metrics.serviceLabels` for discovery by your ServiceMonitor.